### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Code beautifier for Android - a wrapper around a WebView running [HighlightJS](h
 
 ![Screenshot](/screenshot.png)
 
-##Dependency
+## Dependency
 
 Add jitpack.io to your root build.gradle, eg:
 
@@ -30,7 +30,7 @@ You can find the latest version in the releases tab above: https://github.com/fi
 
 More options at jitpack.io: https://jitpack.io/#fiskurgit/SyntaxView
 
-###Licence
+### Licence
 
 Full licence here: https://github.com/fiskurgit/SyntaxView/blob/master/LICENSE
 
@@ -38,11 +38,11 @@ In short:
 
 > The MIT License is a permissive license that is short and to the point. It lets people do anything they want with your code as long as they provide attribution back to you and don’t hold you liable.
 
-###Known Issues
+### Known Issues
 * View lifecycle not implemented, doesn't handle orientation changes
 * Doesn't like large files
 
-##Usage
+## Usage
 
 If loading source code from file add the READ_EXTERNAL_STORAGE permission to your manifest.xml and add the [runtime permission to your Activity/Fragment](https://developer.android.com/training/permissions/requesting.html):
 
@@ -74,7 +74,7 @@ Load file:
 syntaxView.loadFile(file);
 ```
 
-###Theming
+### Theming
 
 All [HighlightJS](https://highlightjs.org/) themes are available (the default is a dark theme called 'monokai-sublime'):
 ```java


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
